### PR TITLE
Make it possible to get value of custom field.

### DIFF
--- a/clickup/custom_fields.go
+++ b/clickup/custom_fields.go
@@ -24,6 +24,27 @@ type CustomField struct {
 	Value          interface{} `json:"value"`
 }
 
+type CurrencyValue struct {
+	Value      float64
+	TypeConfig CurrencyTypeConfig
+}
+
+type CurrencyTypeConfig struct {
+	Precision    float64 `json:"precision"`
+	CurrencyType string  `json:"currency_type"`
+	Default      float64 `json:"default"`
+}
+
+type EmojiValue struct {
+	Value      int
+	TypeConfig EmojiTypeConfig
+}
+
+type EmojiTypeConfig struct {
+	CodePoint string `json:"code_point"`
+	Count     int    `json:"count"`
+}
+
 type LocationValue struct {
 	Latitude         float64
 	Longitude        float64
@@ -107,20 +128,43 @@ func (cf CustomField) GetValue() interface{} {
 		}
 
 		return str
-	case "number", "currency", "formula":
+	case "number", "formula":
 		num, ok := getFloatValue(cf.Value)
 		if !ok {
 			return nil
 		}
 
 		return num
+	case "currency":
+		num, ok := getFloatValue(cf.Value)
+		if !ok {
+			return nil
+		}
+
+		tc := CurrencyTypeConfig{}
+		if ok := getStructValue(cf.TypeConfig, &tc); !ok {
+			return nil
+		}
+
+		return CurrencyValue{
+			Value:      num,
+			TypeConfig: tc,
+		}
 	case "emoji":
 		num, ok := getIntValue(cf.Value)
 		if !ok {
 			return nil
 		}
 
-		return num
+		tc := EmojiTypeConfig{}
+		if ok := getStructValue(cf.TypeConfig, &tc); !ok {
+			return nil
+		}
+
+		return EmojiValue{
+			Value:      int(num),
+			TypeConfig: tc,
+		}
 	case "date":
 		date, ok := getDateValue(cf.Value)
 		if !ok {

--- a/clickup/custom_fields.go
+++ b/clickup/custom_fields.go
@@ -136,12 +136,12 @@ type AttachmentValue struct {
 
 type AttachmentsValue []AttachmentValue
 
-type LabelValue struct {
+type LabelsValue struct {
 	Values     []LabelOption
-	TypeConfig LabelTypeConfig
+	TypeConfig LabelsTypeConfig
 }
 
-type LabelTypeConfig struct {
+type LabelsTypeConfig struct {
 	Options []LabelOption
 }
 
@@ -279,7 +279,7 @@ func (cf CustomField) GetValue() interface{} {
 
 		return v
 	case "labels":
-		v, ok := getLabelValue(cf.Value, cf.TypeConfig)
+		v, ok := getLabelsValue(cf.Value, cf.TypeConfig)
 		if !ok {
 			return nil
 		}
@@ -540,10 +540,10 @@ func getDropDownValue(v, typeConfig interface{}) (DropDownValue, bool) {
 	return ddv, true
 }
 
-func getLabelValue(v, typeConfig interface{}) (LabelValue, bool) {
+func getLabelsValue(v, typeConfig interface{}) (LabelsValue, bool) {
 	arr, ok := v.([]interface{})
 	if !ok {
-		return LabelValue{}, false
+		return LabelsValue{}, false
 	}
 
 	ids := make([]string, len(arr))
@@ -551,12 +551,12 @@ func getLabelValue(v, typeConfig interface{}) (LabelValue, bool) {
 		ids[i] = v.(string)
 	}
 
-	tc := LabelTypeConfig{}
+	tc := LabelsTypeConfig{}
 	if ok := getStructValue(typeConfig, &tc); !ok {
-		return LabelValue{}, false
+		return LabelsValue{}, false
 	}
 
-	lv := LabelValue{
+	lv := LabelsValue{
 		Values:     make([]LabelOption, len(ids)),
 		TypeConfig: tc,
 	}

--- a/clickup/custom_fields.go
+++ b/clickup/custom_fields.go
@@ -151,6 +151,24 @@ type LabelOption struct {
 	Color string
 }
 
+type DropDownValue struct {
+	Value      DropDownOption
+	TypeConfig DropDownTypeConfig
+}
+
+type DropDownTypeConfig struct {
+	Default     float64
+	Placeholder string
+	Options     []DropDownOption
+}
+
+type DropDownOption struct {
+	ID         string
+	OrderIndex int
+	Name       string
+	Color      string
+}
+
 func (cf CustomField) GetValue() interface{} {
 	switch cf.Type {
 	case "url", "email", "phone", "text", "short_text":
@@ -254,7 +272,12 @@ func (cf CustomField) GetValue() interface{} {
 
 		return v
 	case "drop_down":
-		// TODO
+		v, ok := getDropDownValue(cf.Value, cf.TypeConfig)
+		if !ok {
+			return nil
+		}
+
+		return v
 	case "labels":
 		v, ok := getLabelValue(cf.Value, cf.TypeConfig)
 		if !ok {
@@ -488,6 +511,33 @@ func getManualProgressValue(v interface{}, typeConfig interface{}) (ManualProgre
 		Current:          current,
 		TypeConfig:       tc,
 	}, true
+}
+
+func getDropDownValue(v, typeConfig interface{}) (DropDownValue, bool) {
+	ind, ok := v.(float64)
+	if !ok {
+		return DropDownValue{}, false
+	}
+
+	i := int(ind)
+
+	tc := DropDownTypeConfig{}
+	if ok := getStructValue(typeConfig, &tc); !ok {
+		return DropDownValue{}, false
+	}
+
+	ddv := DropDownValue{
+		Value:      DropDownOption{},
+		TypeConfig: tc,
+	}
+
+	for _, option := range tc.Options {
+		if option.OrderIndex == i {
+			ddv.Value = option
+		}
+	}
+
+	return ddv, true
 }
 
 func getLabelValue(v, typeConfig interface{}) (LabelValue, bool) {

--- a/clickup/custom_fields.go
+++ b/clickup/custom_fields.go
@@ -119,7 +119,7 @@ type AttachmentValue struct {
 	Type                json.Number
 	Hidden              bool
 	Size                json.Number
-	ParendId            string
+	ParentId            string
 	ParentCommentType   interface{}
 	ParentCommentParent interface{}
 	EmailData           interface{}

--- a/clickup/custom_fields.go
+++ b/clickup/custom_fields.go
@@ -287,7 +287,7 @@ func (cf CustomField) GetValue() interface{} {
 		return v
 	}
 
-	return nil
+	return cf.Value
 }
 
 func getStringValue(v interface{}) (string, bool) {

--- a/clickup/custom_fields.go
+++ b/clickup/custom_fields.go
@@ -2,7 +2,10 @@ package clickup
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strconv"
+	"time"
 )
 
 type CustomFieldsService service
@@ -11,13 +14,400 @@ type CustomFieldResponse struct {
 	Fields []CustomField `json:"fields"`
 }
 
-// TODO: Add type_config
 type CustomField struct {
-	ID             string `json:"id"`
-	Name           string `json:"name"`
-	Type           string `json:"type"`
-	DateCreated    string `json:"date_created"`
-	HideFromGuests bool   `json:"hide_from_guests"`
+	ID             string      `json:"id"`
+	Name           string      `json:"name"`
+	Type           string      `json:"type"`
+	TypeConfig     interface{} `json:"type_config"`
+	DateCreated    string      `json:"date_created"`
+	HideFromGuests bool        `json:"hide_from_guests"`
+	Value          interface{} `json:"value"`
+}
+
+type LocationValue struct {
+	Latitude         float64
+	Longitude        float64
+	FormattedAddress string
+	PlaceID          string
+}
+
+type AutomaticProgressValue struct {
+	PercentCompleted float64
+}
+
+type ManualProgressValue struct {
+	PercentCompleted float64
+	Current          int64
+}
+
+type TaskValue struct {
+	ID         string
+	Access     bool
+	Color      string
+	CustomId   string
+	CustomType interface{}
+	Deleted    bool
+	Name       string
+	Status     string
+	TeamId     string
+	URL        string
+}
+
+type TasksValue []TaskValue
+
+type UserValue struct {
+	ID             json.Number
+	Username       string
+	Email          string
+	Color          string
+	Initials       string
+	ProfilePicture string
+}
+
+type UsersValue []UserValue
+
+// TODO: Set a concrete type for each field.
+type AttachmentValue struct {
+	ID                  string
+	Version             json.Number
+	Date                json.Number
+	Title               string
+	Extension           string
+	ThumbnailSmall      string
+	ThumbnailMedium     string
+	ThumbnailLarge      string
+	URL                 string
+	Orientation         interface{}
+	Type                json.Number
+	Hidden              bool
+	Size                json.Number
+	ParendId            string
+	ParentCommentType   interface{}
+	ParentCommentParent interface{}
+	EmailData           interface{}
+	UrlWHost            string
+	UrlWQuery           string
+	Source              json.Number
+	IsFolder            interface{}
+	Mimetype            interface{}
+	TotalComments       json.Number
+	ResolvedComments    json.Number
+	Deleted             bool
+	User                UserValue
+}
+
+type AttachmentsValue []AttachmentValue
+
+func (cf CustomField) GetValue() interface{} {
+	switch cf.Type {
+	case "url", "email", "phone", "text", "short_text":
+		str, ok := getStringValue(cf.Value)
+		if !ok {
+			return nil
+		}
+
+		return str
+	case "number", "currency", "formula":
+		num, ok := getFloatValue(cf.Value)
+		if !ok {
+			return nil
+		}
+
+		return num
+	case "emoji":
+		num, ok := getIntValue(cf.Value)
+		if !ok {
+			return nil
+		}
+
+		return num
+	case "date":
+		date, ok := getDateValue(cf.Value)
+		if !ok {
+			return nil
+		}
+
+		return date
+	case "checkbox":
+		b, ok := getBoolValue(cf.Value)
+		if !ok {
+			return nil
+		}
+
+		return b
+	case "location":
+		loc, ok := getLocationValue(cf.Value)
+		if !ok {
+			return nil
+		}
+
+		return loc
+	case "automatic_progress":
+		prog, ok := getAutomaticProgressValue(cf.Value)
+		if !ok {
+			return nil
+		}
+
+		return prog
+	case "manual_progress":
+		prog, ok := getManualProgressValue(cf.Value)
+		if !ok {
+			return nil
+		}
+
+		return prog
+	case "tasks":
+		v := TasksValue{}
+		if ok := getStructValue(cf.Value, &v); !ok {
+			return nil
+		}
+
+		return v
+	case "users":
+		v := UsersValue{}
+		if ok := getStructValue(cf.Value, &v); !ok {
+			return nil
+		}
+
+		return v
+	case "attachment":
+		v := AttachmentsValue{}
+		if ok := getStructValue(cf.Value, &v); !ok {
+			return nil
+		}
+
+		return v
+	case "drop_down":
+		// TODO
+	case "labels":
+		// TODO
+	}
+
+	return nil
+}
+
+func getStringValue(v interface{}) (string, bool) {
+	str, ok := v.(string)
+	if !ok {
+		return "", false
+	}
+
+	return str, true
+}
+
+func getFloatValue(v interface{}) (float64, bool) {
+	switch v := v.(type) {
+	case int:
+		return float64(v), true
+	case float64:
+		return v, true
+	case string:
+		num, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return 0, false
+		}
+
+		return num, true
+	}
+
+	return 0, false
+}
+
+func getIntValue(v interface{}) (int64, bool) {
+	switch v := v.(type) {
+	case int:
+		return int64(v), true
+	case string:
+		num, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+
+		return num, true
+	}
+
+	return 0, false
+}
+
+func getDateValue(v interface{}) (time.Time, bool) {
+	num, ok := getIntValue(v)
+	if !ok {
+		return time.Time{}, false
+	}
+
+	return time.UnixMilli(num), true
+}
+
+func getBoolValue(v interface{}) (bool, bool) {
+	str, ok := v.(string)
+	if !ok {
+		return false, false
+	}
+
+	b, err := strconv.ParseBool(str)
+	if err != nil {
+		return false, false
+	}
+
+	return b, true
+}
+
+func getLocationValue(v interface{}) (LocationValue, bool) {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return LocationValue{}, false
+	}
+
+	loc := LocationValue{}
+
+	for k, v := range m {
+		switch k {
+		case "location":
+			v, ok := v.(map[string]interface{})
+			if !ok {
+				return LocationValue{}, false
+			}
+
+			lat, ok := func() (float64, bool) {
+				lat, ok := v["lat"]
+				if !ok {
+					return 0, false
+				}
+
+				num, ok := lat.(float64)
+				if !ok {
+					return 0, false
+				}
+
+				return num, true
+			}()
+			if !ok {
+				return LocationValue{}, false
+			}
+
+			loc.Latitude = lat
+
+			lng, ok := func() (float64, bool) {
+				lng, ok := v["lng"]
+				if !ok {
+					return 0, false
+				}
+
+				num, ok := lng.(float64)
+				if !ok {
+					return 0, false
+				}
+
+				return num, true
+			}()
+			if !ok {
+				return LocationValue{}, false
+			}
+
+			loc.Longitude = lng
+		case "formatted_address":
+			str, ok := v.(string)
+			if !ok {
+				return LocationValue{}, false
+			}
+
+			loc.FormattedAddress = str
+		case "place_id":
+			str, ok := v.(string)
+			if !ok {
+				return LocationValue{}, false
+			}
+
+			loc.PlaceID = str
+		}
+	}
+
+	return loc, true
+}
+
+func getAutomaticProgressValue(v interface{}) (AutomaticProgressValue, bool) {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return AutomaticProgressValue{}, false
+	}
+
+	percentStr, ok := m["percent_complete"]
+	if !ok {
+		return AutomaticProgressValue{}, false
+	}
+
+	percent, ok := percentStr.(float64)
+	if !ok {
+		return AutomaticProgressValue{}, false
+	}
+
+	return AutomaticProgressValue{
+		PercentCompleted: percent,
+	}, true
+}
+
+func getManualProgressValue(v interface{}) (ManualProgressValue, bool) {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return ManualProgressValue{}, false
+	}
+
+	percent, ok := func() (float64, bool) {
+		percent, ok := m["percent_completed"]
+		if !ok {
+			return 0, false
+		}
+
+		num, ok := percent.(float64)
+		if !ok {
+			return 0, false
+		}
+
+		return num, true
+	}()
+	if !ok {
+		return ManualProgressValue{}, false
+	}
+
+	current, ok := func() (int64, bool) {
+		current, ok := m["current"]
+		if !ok {
+			return 0, false
+		}
+
+		str, ok := current.(string)
+		if !ok {
+			return 0, false
+		}
+
+		i, err := strconv.ParseInt(str, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+
+		return i, true
+	}()
+	if !ok {
+		return ManualProgressValue{}, false
+	}
+
+	return ManualProgressValue{
+		PercentCompleted: percent,
+		Current:          current,
+	}, true
+}
+
+func getStructValue(src, dst interface{}) bool {
+	b, err := json.Marshal(src)
+	if err != nil {
+		return false
+	}
+
+	if err := json.Unmarshal(b, &dst); err != nil {
+		return false
+	}
+
+	return true
 }
 
 type CustomFieldOptions struct {

--- a/example/custom-fields/main.go
+++ b/example/custom-fields/main.go
@@ -1,0 +1,173 @@
+// The simple command demonstrates the functionality that
+// prompts the user for a Clickup task and lists the values
+// of all custom fields for the given task.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/raksul/go-clickup/clickup"
+)
+
+func main() {
+	api_key := os.Getenv("CLICKUP_API_KEY")
+	client := clickup.NewClient(nil, api_key)
+
+	task, _, err := client.Tasks.GetTask(context.Background(), "2v1etep", nil)
+
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
+	fmt.Println(task.Name)
+	for _, field := range task.CustomFields {
+		fmt.Println("---------------------------")
+		fmt.Println("CutomField.Type:", field.Type)
+		fmt.Println()
+
+		switch v := field.GetValue().(type) {
+		case string:
+			fmt.Println("string:", v)
+		case float64:
+			fmt.Println("float64:", v)
+		case bool:
+			fmt.Println("bool:", v)
+		case time.Time:
+			fmt.Println("time.Time:", v.Format(time.RFC822))
+		case clickup.CurrencyValue:
+			fmt.Println("CurrencyValue:")
+			fmt.Println("	Value:", v.Value)
+			fmt.Println("	TypeConfig:")
+			fmt.Println("		CurrencyType:", v.TypeConfig.CurrencyType)
+			fmt.Println("		Precision:", v.TypeConfig.Precision)
+			fmt.Println("		Default:", v.TypeConfig.Default)
+		case clickup.EmojiValue:
+			fmt.Println("EmojiValue:")
+			fmt.Println("	Value:", v.Value)
+			fmt.Println("	TypeConfig:")
+			fmt.Println("		CodePoint:", v.TypeConfig.CodePoint)
+			fmt.Println("		Count:", v.TypeConfig.Count)
+		case clickup.LocationValue:
+			fmt.Println("LocationValue:")
+			fmt.Println("	Latitude:", v.Latitude)
+			fmt.Println("	Longitude:", v.Longitude)
+			fmt.Println("	FormattedAddress:", v.FormattedAddress)
+			fmt.Println("	PlaceID:", v.PlaceID)
+		case clickup.AutomaticProgressValue:
+			fmt.Println("AutomaticProgressValue:")
+			fmt.Println("	PercentCompleted:", v.PercentCompleted)
+			fmt.Println("	TypeConfig:")
+			fmt.Println("		CompleteOn:", v.TypeConfig.CompleteOn)
+			fmt.Println("		SubtaskRollup:", v.TypeConfig.SubtaskRollup)
+			fmt.Println("		Tracking:")
+			fmt.Println("			AssignedComments:", v.TypeConfig.Tracking.AssignedComments)
+			fmt.Println("			Checklist:", v.TypeConfig.Tracking.Checklist)
+			fmt.Println("			Subtasks:", v.TypeConfig.Tracking.Subtasks)
+		case clickup.ManualProgressValue:
+			fmt.Println("ManualProgressValue:")
+			fmt.Println("	Current:", v.Current)
+			fmt.Println("	PercentCompleted:", v.PercentCompleted)
+			fmt.Println("	TypeConfig:")
+			fmt.Println("		End:", v.TypeConfig.End)
+			fmt.Println("		Start:", v.TypeConfig.Start)
+		case clickup.TasksValue:
+			fmt.Println("TasksValue:")
+			for i, task := range v {
+				fmt.Println("[", i, "]")
+				fmt.Println("	ID:", task.ID)
+				fmt.Println("	Name:", task.Name)
+				fmt.Println("	CustomId:", task.CustomId)
+				fmt.Println("	CustomType:", task.CustomType)
+				fmt.Println("	Status:", task.Status)
+				fmt.Println("	Color:", task.Color)
+				fmt.Println("	Deleted:", task.Deleted)
+				fmt.Println("	TeamId:", task.TeamId)
+				fmt.Println("	URL:", task.URL)
+			}
+		case clickup.UsersValue:
+			fmt.Println("UsersValue:")
+			for i, user := range v {
+				fmt.Println("[", i, "]")
+				fmt.Println("	ID:", user.ID)
+				fmt.Println("	Username:", user.Username)
+				fmt.Println("	Initials:", user.Initials)
+				fmt.Println("	Email:", user.Email)
+				fmt.Println("	Color:", user.Color)
+				fmt.Println("	ProfilePicture:", user.ProfilePicture)
+			}
+		case clickup.AttachmentsValue:
+			fmt.Println("AttachmentsValue:")
+			for i, attachment := range v {
+				fmt.Println("[", i, "]")
+				fmt.Println("	ID:", attachment.ID)
+				fmt.Println("	Date:", attachment.Date)
+				fmt.Println("	Deleted:", attachment.Deleted)
+				fmt.Println("	EmailData:", attachment.EmailData)
+				fmt.Println("	Extension:", attachment.Extension)
+				fmt.Println("	Hidden:", attachment.Hidden)
+				fmt.Println("	IsFolder:", attachment.IsFolder)
+				fmt.Println("	Mimetype:", attachment.Mimetype)
+				fmt.Println("	Orientation:", attachment.Orientation)
+				fmt.Println("	ParentID:", attachment.ParentId)
+				fmt.Println("	ParentCommentParent:", attachment.ParentCommentParent)
+				fmt.Println("	ParentCommentType:", attachment.ParentCommentType)
+				fmt.Println("	ResolvedComments:", attachment.ResolvedComments)
+				fmt.Println("	Size:", attachment.Size)
+				fmt.Println("	Source:", attachment.Source)
+				fmt.Println("	ThumbnailLarge:", attachment.ThumbnailLarge)
+				fmt.Println("	ThumbnailMedium:", attachment.ThumbnailMedium)
+				fmt.Println("	ThumbnailSmall:", attachment.ThumbnailSmall)
+				fmt.Println("	Title:", attachment.Title)
+				fmt.Println("	TotalComments:", attachment.TotalComments)
+				fmt.Println("	Type:", attachment.Type)
+				fmt.Println("	URL:", attachment.URL)
+				fmt.Println("	UrlWHost:", attachment.UrlWHost)
+				fmt.Println("	UrlWQuery:", attachment.UrlWQuery)
+				fmt.Println("	Version:", attachment.Version)
+				fmt.Println("	Users:")
+				fmt.Println("		Username:", attachment.User.Username)
+				fmt.Println("		Email:", attachment.User.Email)
+				fmt.Println("		ID:", attachment.User.ID)
+			}
+		case clickup.DropDownValue:
+			fmt.Println("DropDownValue:")
+			fmt.Println("	Value:")
+			fmt.Println("		OrderIndex:", v.Value.OrderIndex)
+			fmt.Println("		ID:", v.Value.ID)
+			fmt.Println("		Name:", v.Value.Name)
+			fmt.Println("		Color:", v.Value.Color)
+			fmt.Println("	TypeConfig:")
+			fmt.Println("		Options:")
+			for i, option := range v.TypeConfig.Options {
+				fmt.Println("		[", i, "]")
+				fmt.Println("			ID:", option.ID)
+				fmt.Println("			Name:", option.Name)
+				fmt.Println("			Color:", option.Color)
+			}
+		case clickup.LabelsValue:
+			fmt.Println("LabelsValue:")
+			fmt.Println("	Value:")
+			for i, v := range v.Values {
+				fmt.Println("	[", i, "]")
+				fmt.Println("		ID:", v.ID)
+				fmt.Println("		Label:", v.Label)
+				fmt.Println("		Color:", v.Color)
+			}
+			fmt.Println("	TypeConfig:")
+			fmt.Println("		Options:")
+			for i, option := range v.TypeConfig.Options {
+				fmt.Println("		[", i, "]")
+				fmt.Println("			ID:", option.ID)
+				fmt.Println("			Label:", option.Label)
+				fmt.Println("			Color:", option.Color)
+			}
+		default:
+			fmt.Printf("%#v\n", v)
+			panic("unknow type")
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.16
 require (
 	github.com/google/go-cmp v0.5.2
 	github.com/google/go-querystring v1.1.0
-	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This PR make it possible to get value of custom field via Get Task API.

```
task, _, _ := client.Tasks.GetTask(ctx, id, nil)

for _, field := range task.CustomFields {
  v := field.GetValue() // value of custom field
  
  // process to use v
  
}
```

`GetValue()` returns interface value. It can be cast in concrete type. What type can be cast depends on the `CustomField.Type` as shown in the table below.

| `CustomField.Type` | Type of `GetValue()` returns value |
| - | - |
| url, email, phone, text, short_text | `string` |
| number, formula | `float64` |
| checkbox | `bool` |
| date | `time.Time` |
| currency | `clickup.CurrencyValue` |
| emoji | `clickup.EmojiValue` |
| location | `clickup.LocationValue` |
| automatic_progress | `clickup.AutomaticProgressValue` |
| manual_progress | `clickup.ManualProgressValue` |
| tasks | `clickup.TasksValue` |
| users | `clickup.UsersValue` |
| attachment | `clickup.AttachmentValue` |
| drop_down | `clickup.DropDownValue` |
| labels | `clickup.LabelsValue` |

For more details, please see the example code (`example/custom-fields/main.go`) .