### PR TITLE
Add Date type to update/remove the due date of a Task.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     name: Test and lint
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.19.x]
         platform: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
 

--- a/clickup/comments.go
+++ b/clickup/comments.go
@@ -22,7 +22,7 @@ type UpdateCommentRequest struct {
 type CreateCommentResponse struct {
 	ID     string `json:"id"`
 	HistId string `json:"hist_id"`
-	Date   int64  `json:"date"`
+	Date   *Date  `json:"date"`
 }
 
 type GetCommentsResponse struct {

--- a/clickup/comments_test.go
+++ b/clickup/comments_test.go
@@ -44,7 +44,7 @@ func TestCommentsService_CreateTaskComment(t *testing.T) {
 		t.Errorf("Actions.ListArtifacts returned error: %v", err)
 	}
 
-	want := &CreateCommentResponse{ID: "458", HistId: "26508", Date: 1568036964079}
+	want := &CreateCommentResponse{ID: "458", HistId: "26508", Date: NewDateWithUnixTime(1568036964079)}
 	if !cmp.Equal(artifacts, want) {
 		t.Errorf("Actions.ListArtifacts returned %+v, want %+v", artifacts, want)
 	}

--- a/clickup/date.go
+++ b/clickup/date.go
@@ -1,0 +1,113 @@
+package clickup
+
+import (
+	"encoding/json"
+	"strconv"
+	"time"
+)
+
+type Date struct {
+	unix json.Number
+	time time.Time
+	null bool
+}
+
+func NewDate(t time.Time) *Date {
+	return &Date{
+		unix: int64ToJsonNumber(t.UnixMilli()),
+		time: t,
+	}
+}
+
+func NewDateWithUnixTime(unix int64) *Date {
+	return &Date{
+		unix: int64ToJsonNumber(unix),
+		time: time.UnixMilli(unix),
+	}
+}
+
+func NullDate() *Date {
+	return &Date{null: true}
+}
+
+func (d Date) Time() *time.Time {
+	if d.null {
+		return nil
+	}
+
+	return &d.time
+}
+
+func (d Date) String() string {
+	if d.null {
+		return ""
+	}
+
+	return d.time.String()
+}
+
+// Equal reports whether x and y are equal.
+// This method was added to test with google/go-cmp.
+// ref: https://pkg.go.dev/github.com/google/go-cmp/cmp#Equal
+func (x Date) Equal(y Date) bool {
+	if x.null {
+		return x.null == y.null
+	}
+
+	return x.time.Equal(y.time)
+}
+
+func (d *Date) UnmarshalJSON(b []byte) error {
+	var str string
+	if err := json.Unmarshal(b, &str); err == nil {
+		if str == "" {
+			d.null = true
+
+			return nil
+		}
+	}
+
+	var v json.Number
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+
+	n, err := jsonNumberToInt64(v)
+	if err != nil {
+		return err
+	}
+
+	d.unix = v
+	d.time = time.UnixMilli(n)
+	d.null = false
+
+	return nil
+}
+
+func (d Date) MarshalJSON() ([]byte, error) {
+	if d.null {
+		return json.Marshal(nil)
+	}
+
+	return json.Marshal(d.unix)
+}
+
+func int64ToJsonNumber(n int64) json.Number {
+	b := []byte(strconv.Itoa(int(n)))
+
+	var v json.Number
+	if err := json.Unmarshal(b, &v); err != nil {
+		panic(err.Error())
+	}
+
+	return v
+}
+
+func jsonNumberToInt64(num json.Number) (int64, error) {
+	n, err := num.Int64()
+	if err != nil {
+		return 0, err
+	}
+
+	return n, nil
+}

--- a/clickup/goals.go
+++ b/clickup/goals.go
@@ -18,7 +18,7 @@ type GetGoalResponse struct {
 
 type CreateGoalRequest struct {
 	Name           string `json:"name"`
-	DueDate        int64  `json:"due_date"`
+	DueDate        *Date  `json:"due_date"`
 	Description    string `json:"description"`
 	MultipleOwners bool   `json:"multiple_owners"`
 	Owners         []int  `json:"owners"`
@@ -27,7 +27,7 @@ type CreateGoalRequest struct {
 
 type UpdateGoalRequest struct {
 	Name        string `json:"name"`
-	DueDate     int64  `json:"due_date"`
+	DueDate     *Date  `json:"due_date"`
 	Description string `json:"description"`
 	RemOwners   []int  `json:"rem_owners"`
 	AddOwners   []int  `json:"add_owners"`

--- a/clickup/lists.go
+++ b/clickup/lists.go
@@ -15,7 +15,7 @@ type GetListsResponse struct {
 type ListRequest struct {
 	Name        string `json:"name"`
 	Content     string `json:"content"`
-	DueDate     int64  `json:"due_date"`
+	DueDate     *Date  `json:"due_date"`
 	DueDateTime bool   `json:"due_date_time"`
 	Priority    int    `json:"priority"`
 	Assignee    int    `json:"assignee"`

--- a/clickup/tasks.go
+++ b/clickup/tasks.go
@@ -21,10 +21,10 @@ type TaskRequest struct {
 	Tags                      []string                   `json:"tags,omitempty"`
 	Status                    string                     `json:"status,omitempty"`
 	Priority                  int                        `json:"priority,omitempty"`
-	DueDate                   int64                      `json:"due_date,omitempty"`
+	DueDate                   *Date                      `json:"due_date,omitempty"`
 	DueDateTime               bool                       `json:"due_date_time,omitempty"`
 	TimeEstimate              int                        `json:"time_estimate,omitempty"`
-	StartDate                 int64                      `json:"start_date,omitempty"`
+	StartDate                 *Date                      `json:"start_date,omitempty"`
 	StartDateTime             bool                       `json:"start_date_time,omitempty"`
 	NotifyAll                 bool                       `json:"notify_all,omitempty"`
 	Parent                    string                     `json:"parent,omitempty"`
@@ -57,7 +57,7 @@ type Task struct {
 	Tags            []Tag                  `json:"tags,omitempty"`
 	Parent          string                 `json:"parent"`
 	Priority        TaskPriority           `json:"priority"`
-	DueDate         string                 `json:"due_date,omitempty"`
+	DueDate         *Date                  `json:"due_date,omitempty"`
 	StartDate       string                 `json:"start_date,omitempty"`
 	Points          int                    `json:"points,omitempty"`
 	TimeEstimate    int64                  `json:"time_estimate"`
@@ -159,12 +159,12 @@ type GetTasksOptions struct {
 	Statuses      []string `url:"statuses[],omitempty"`
 	IncludeClosed bool     `url:"include_closed,omitempty"`
 	Assignees     []string `url:"assignees[],omitempty"`
-	DueDateGt     int64    `url:"due_date_gt,omitempty"`
-	DueDateLt     int64    `url:"due_date_lt,omitempty"`
-	DateCreatedGt int64    `url:"date_created_gt,omitempty"`
-	DateCreatedLt int64    `url:"date_created_lt,omitempty"`
-	DateUpdatedGt int64    `url:"date_updated_gt,omitempty"`
-	DateUpdatedLt int64    `url:"date_updated_lt,omitempty"`
+	DueDateGt     Date     `url:"due_date_gt,omitempty"`
+	DueDateLt     Date     `url:"due_date_lt,omitempty"`
+	DateCreatedGt *Date    `url:"date_created_gt,omitempty"`
+	DateCreatedLt *Date    `url:"date_created_lt,omitempty"`
+	DateUpdatedGt *Date    `url:"date_updated_gt,omitempty"`
+	DateUpdatedLt *Date    `url:"date_updated_lt,omitempty"`
 }
 
 type GetTaskOptions struct {

--- a/example/update-duedate/main.go
+++ b/example/update-duedate/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/raksul/go-clickup/clickup"
+)
+
+func main() {
+	var taskId string
+	fmt.Print("Enter clickup taskId: ")
+	fmt.Scanf("%s", &taskId)
+
+	ctx := context.Background()
+	api_key := os.Getenv("CLICKUP_API_KEY")
+	client := clickup.NewClient(nil, api_key)
+
+	fmt.Println("\nGet due date of current task")
+	getTask(ctx, client, taskId)
+
+	fmt.Println("\nUpdate due date of the task to 2122/01/02 03:04:05:06")
+	updateTask(ctx, client, taskId, &clickup.TaskRequest{
+		DueDate: clickup.NewDate(
+			time.Date(2122, 1, 2, 3, 4, 5, 6, time.Now().Location()),
+		),
+	})
+
+	fmt.Println("\nUpdate the task with empty TaskRequest")
+	updateTask(ctx, client, taskId, &clickup.TaskRequest{})
+
+	fmt.Println("\nRemove task due date with NullDate()")
+	updateTask(ctx, client, taskId, &clickup.TaskRequest{
+		DueDate: clickup.NullDate(),
+	})
+}
+
+func getTask(ctx context.Context, client *clickup.Client, taskID string) {
+	task, _, err := client.Tasks.GetTask(ctx, taskID, &clickup.GetTaskOptions{})
+	if err != nil {
+		log.Fatalln(err)
+	}
+	fmt.Println(task.Name, task.DueDate)
+}
+
+func updateTask(ctx context.Context, client *clickup.Client, taskID string, tr *clickup.TaskRequest) {
+	task, _, err := client.Tasks.UpdateTask(ctx, taskID, &clickup.GetTasksOptions{}, tr)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	fmt.Println(task.Name, task.DueDate)
+}

--- a/example/update-duedate/main.go
+++ b/example/update-duedate/main.go
@@ -1,3 +1,7 @@
+// This example shows that the due date of a task can be updated.
+// If you do not specify a due date it will remain the same,
+// and if you specify clickup.NullDate() it will be removed.
+
 package main
 
 import (


### PR DESCRIPTION
This PR adds a Date type to update or remove the due date of a Task.

This is the execution result of the sample code to update and remove the due date of the task whose ID is `376jy0a` (`ccc` is the task name).
```
$ go run example/update-duedate/main.go
Enter clickup taskId: 376jy0a

Get due date of current task
ccc 2022-11-17 04:00:00 +0900 JST

Update due date of the task to 2122/01/02 03:04:05:06
ccc 2122-01-02 04:00:00 +0900 JST

Update the task with empty TaskRequest
ccc 2122-01-02 04:00:00 +0900 JST

Remove task due date with NullDate()
ccc <nil>
```